### PR TITLE
feat(marquee): short-card variant

### DIFF
--- a/libs/blocks/card/card.css
+++ b/libs/blocks/card/card.css
@@ -10,3 +10,112 @@
   width: 100%;
   margin-bottom: var(--spacing-xs);
 }
+
+.consonant-ShortCard,
+.consonant-ShortCard:hover {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 225px;
+  width: 100vw;
+  min-height: 200px;
+  height: 330px;
+  font-size: 0;
+  line-height: 0;
+  border: 1px solid #eaeaea;
+  border-radius: 4px;
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 0.3s ease;
+}
+
+.consonant-CardsGrid > .card.short-card.border {
+  display: flex;
+  justify-content: center;
+}
+
+.consonant-ShortCard:hover {
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.consonant-ShortCard-img {
+  flex-grow: 1;
+  position: relative;
+  width: 100%;
+  min-height: 213px;
+  max-height: 213px;
+  background-color: #eaeaea;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.consonant-ShortCard-img::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0);
+  transition: background-color 0.3s ease;
+}
+
+.consonant-ShortCard:hover .consonant-ShortCard-img::before {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.consonant-ShortCard-inner,
+.consonant-ShortCard-inner:hover {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 200px;
+  padding: 20px 24px 24px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  background-color: #fff;
+  text-decoration: none;
+  max-width: 100%;
+}
+
+.consonant-ShortCard-title {
+  margin: 0 0 5px;
+  padding: 0;
+  font-family: adobe-clean, Segoe UI, Roboto, sans-serif;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-weight: 700;
+  color: #323232;
+  font-style: normal;
+  word-break: break-word;
+  text-align: left;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+
+.consonant-ShortCard-text {
+  margin: 0;
+  padding: 0;
+  font-family: adobe-clean, Segoe UI, Roboto, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.3125rem;
+  font-weight: 400;
+  color: #747474;
+  font-style: normal;
+  word-break: break-word;
+  text-align: left;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.milo-card-wrapper.consonant-Wrapper {
+  margin-top: 0;
+}

--- a/libs/blocks/card/card.js
+++ b/libs/blocks/card/card.js
@@ -7,6 +7,7 @@ const HALF = 'OneHalfCard';
 const HALF_HEIGHT = 'HalfHeightCard';
 const PRODUCT = 'ProductCard';
 const DOUBLE_WIDE = 'DoubleWideCard';
+const SHORT = 'ShortCard';
 
 const getCardType = (styles) => {
   const cardTypes = {
@@ -14,6 +15,7 @@ const getCardType = (styles) => {
     'half-height-card': HALF_HEIGHT,
     'product-card': PRODUCT,
     'double-width-card': DOUBLE_WIDE,
+    'short-card': SHORT,
   };
   const authoredType = styles?.find((style) => style in cardTypes);
   return cardTypes[authoredType] || HALF;
@@ -73,7 +75,7 @@ const addInner = (el, cardType, card) => {
   const text = Array.from(el.querySelectorAll('p'))?.find((p) => !p.querySelector('picture, a'));
   let inner = el.querySelector(':scope > div:not([class])');
 
-  if (cardType === DOUBLE_WIDE) {
+  if (cardType === DOUBLE_WIDE || cardType === SHORT) {
     inner = document.createElement('a');
     inner.href = el.querySelector('a')?.href || '';
     inner.rel = 'noopener noreferrer';
@@ -135,7 +137,7 @@ const init = (el) => {
 
   addWrapper(el, section, cardType);
 
-  if (cardType === HALF_HEIGHT) {
+  if (cardType === HALF_HEIGHT || cardType === SHORT) {
     const [link] = links;
 
     if (link) {

--- a/test/blocks/card/card.test.js
+++ b/test/blocks/card/card.test.js
@@ -76,6 +76,23 @@ describe('Card', () => {
     });
   });
 
+  describe('Short Card', () => {
+    before(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/short.html' });
+    });
+
+    it('is supported', () => {
+      init(document.querySelector('.card'));
+      expect(document.querySelector('.consonant-ShortCard')).to.exist;
+    });
+
+    it('does not display undefined if no content', async () => {
+      const el = document.querySelector('.card.empty');
+      init(el);
+      expect(el.outerHTML.includes('undefined')).to.be.false;
+    });
+  });
+
   describe('Two-Up Cards', () => {
     before(async () => {
       document.body.innerHTML = await readFile({ path: './mocks/two-up-cards.html' });

--- a/test/blocks/card/mocks/short.html
+++ b/test/blocks/card/mocks/short.html
@@ -1,0 +1,24 @@
+<div class="section">
+  <div class="card short-card">
+    <div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="" media="(min-width: 400px)">
+            <source type="image/webp" srcset="">
+            <source type="image/jpeg" srcset="" media="(min-width: 400px)">
+            <img loading="eager" alt="" type="image/jpeg" src="" width="1440" height="480">
+          </picture>
+        </p>
+        <h3 id="lorem-ipsum-dolor-sit-amet">Lorem ipsum dolor sit amet</h3>
+        <p>Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>
+        <p><em><a href="https://business.adobe.com/">Sign up</a></em> <strong><a href="https://business.adobe.com/">Learn more</a></strong></p>
+      </div>
+    </div>
+  </div>
+  <div class="card short-card empty">
+    <div>
+      <div></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adobe Stock requested a card that would remove the extra white space below the text description without showing the CTA button and instead get that link and apply it to the whole card itself to make it clickable.

The goal is to make the new variant look like the double width card but clickable like the one-half card variant.

**Description**

- Added some custom CSS in the card.css
- Added the ShortCard card variant in card.js

**Test URLs:**
Sample page for Artist Spotlight Hub

- Before: https://main--adobestock--adobecom.hlx.page/drafts/sandra/artist-spotlight
- After: https://shortcard--adobestock--wbstry.hlx.page/drafts/sandra/artist-spotlight?milolibs=shortcard&milofork=wbstry